### PR TITLE
Adding AdditionalMetadata config

### DIFF
--- a/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/metadata/arbitrum.protocol-token.json
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/metadata/arbitrum.protocol-token.json
@@ -1,6 +1,6 @@
 [
   {
-    "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+    "address": "0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C",
     "name": "Mountain Protocol USD",
     "symbol": "USDM",
     "decimals": 18,

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/metadata/arbitrum.protocol-token.json
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/metadata/arbitrum.protocol-token.json
@@ -1,0 +1,16 @@
+[
+  {
+    "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+    "name": "Mountain Protocol USD",
+    "symbol": "USDM",
+    "decimals": 18,
+    "underlyingTokens": [
+      {
+        "address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+        "symbol": "USDC",
+        "name": "Token USDC",
+        "decimals": 6
+      }
+    ]
+  }
+]

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/metadata/base.protocol-token.json
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/metadata/base.protocol-token.json
@@ -1,6 +1,6 @@
 [
   {
-    "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+    "address": "0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C",
     "name": "Mountain Protocol USD",
     "symbol": "USDM",
     "decimals": 18,

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/metadata/base.protocol-token.json
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/metadata/base.protocol-token.json
@@ -1,0 +1,16 @@
+[
+  {
+    "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+    "name": "Mountain Protocol USD",
+    "symbol": "USDM",
+    "decimals": 18,
+    "underlyingTokens": [
+      {
+        "address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        "symbol": "USDC",
+        "name": "Token USDC",
+        "decimals": 6
+      }
+    ]
+  }
+]

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/metadata/ethereum.protocol-token.json
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/metadata/ethereum.protocol-token.json
@@ -1,6 +1,6 @@
 [
   {
-    "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+    "address": "0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C",
     "name": "Mountain Protocol USD",
     "symbol": "USDM",
     "decimals": 18,

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/metadata/ethereum.protocol-token.json
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/metadata/ethereum.protocol-token.json
@@ -1,0 +1,16 @@
+[
+  {
+    "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+    "name": "Mountain Protocol USD",
+    "symbol": "USDM",
+    "decimals": 18,
+    "underlyingTokens": [
+      {
+        "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        "symbol": "USDC",
+        "name": "Token USDC",
+        "decimals": 6
+      }
+    ]
+  }
+]

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/metadata/optimism.protocol-token.json
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/metadata/optimism.protocol-token.json
@@ -1,6 +1,6 @@
 [
   {
-    "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+    "address": "0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C",
     "name": "Mountain Protocol USD",
     "symbol": "USDM",
     "decimals": 18,

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/metadata/optimism.protocol-token.json
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/metadata/optimism.protocol-token.json
@@ -1,0 +1,16 @@
+[
+  {
+    "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+    "name": "Mountain Protocol USD",
+    "symbol": "USDM",
+    "decimals": 18,
+    "underlyingTokens": [
+      {
+        "address": "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
+        "symbol": "USDC",
+        "name": "Token USDC",
+        "decimals": 6
+      }
+    ]
+  }
+]

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/metadata/polygon.protocol-token.json
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/metadata/polygon.protocol-token.json
@@ -1,6 +1,6 @@
 [
   {
-    "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+    "address": "0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C",
     "name": "Mountain Protocol USD",
     "symbol": "USDM",
     "decimals": 18,

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/metadata/polygon.protocol-token.json
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/metadata/polygon.protocol-token.json
@@ -1,0 +1,16 @@
+[
+  {
+    "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+    "name": "Mountain Protocol USD",
+    "symbol": "USDM",
+    "decimals": 18,
+    "underlyingTokens": [
+      {
+        "address": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+        "symbol": "USDC",
+        "name": "Token USDC",
+        "decimals": 6
+      }
+    ]
+  }
+]

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/mountainProtocolUsdmAdapter.ts
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/mountainProtocolUsdmAdapter.ts
@@ -103,7 +103,7 @@ export class MountainProtocolUsdmAdapter extends SimplePoolAdapter<AdditionalMet
 
     const underlyingTokenBalance = {
       ...underlyingToken!,
-      balanceRaw: protocolTokenBalance.balanceRaw,
+      balanceRaw: BigInt(1 ** 6),
       type: TokenType.Underlying,
     }
 
@@ -117,8 +117,8 @@ export class MountainProtocolUsdmAdapter extends SimplePoolAdapter<AdditionalMet
       PROTOCOL_TOKEN_ADDRESS,
     )
 
-    // Always pegged one to one to underlying
-    const pricePerShareRaw = BigInt(10 ** protocolTokenMetadata.decimals)
+    // Convertion of underlying share to protocol token
+    const pricePerShareRaw = BigInt(10 ** underlyingToken!.decimals)
 
     return [
       {

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/mountainProtocolUsdmAdapter.ts
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/mountainProtocolUsdmAdapter.ts
@@ -30,7 +30,7 @@ type AdditionalMetadata = {
   underlyingTokens: Erc20Metadata[]
 }
 
-const PROTOCOL_TOKEN_ADDRESS = '0x59d9356e565ab3a36dd77763fc0d87feaf85508c'
+const PROTOCOL_TOKEN_ADDRESS = '0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C'
 export class MountainProtocolUsdmAdapter extends SimplePoolAdapter<AdditionalMetadata> {
   productId = 'usdm'
 
@@ -66,7 +66,7 @@ export class MountainProtocolUsdmAdapter extends SimplePoolAdapter<AdditionalMet
             address: this.getUSDCAddress(),
             symbol: 'USDC',
             name: 'USD Coin',
-            decimals: 18,
+            decimals: 6,
           },
         ],
       },

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/mountainProtocolUsdmAdapter.ts
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/mountainProtocolUsdmAdapter.ts
@@ -30,7 +30,7 @@ type AdditionalMetadata = {
   underlyingTokens: Erc20Metadata[]
 }
 
-const PROTOCOL_TOKEN_ADDRESS = '0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C'
+const PROTOCOL_TOKEN_ADDRESS = '0x59d9356e565ab3a36dd77763fc0d87feaf85508c'
 export class MountainProtocolUsdmAdapter extends SimplePoolAdapter<AdditionalMetadata> {
   productId = 'usdm'
 

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/mountainProtocolUsdmAdapter.ts
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/usdm/mountainProtocolUsdmAdapter.ts
@@ -117,7 +117,9 @@ export class MountainProtocolUsdmAdapter extends SimplePoolAdapter<AdditionalMet
       PROTOCOL_TOKEN_ADDRESS,
     )
 
-    // Convertion of underlying share to protocol token
+    // Not really clear how this works, but it seems that using USDC shares makes it work
+    // Basically if we were to set this to BigInt(10 ** 18) as any other ERC20
+    // The balance would add 12 extra 0's
     const pricePerShareRaw = BigInt(10 ** underlyingToken!.decimals)
 
     return [

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/metadata/arbitrum.protocol-token.json
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/metadata/arbitrum.protocol-token.json
@@ -1,0 +1,16 @@
+[
+  {
+    "address": "0x57F5E098CaD7A3D1Eed53991D4d66C45C9AF7812",
+    "name": "Wrapped Mountain Protocol USD",
+    "symbol": "wUSDM",
+    "decimals": 18,
+    "underlyingTokens": [
+      {
+        "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+        "symbol": "USDM",
+        "name": "Mountain Protocol USD",
+        "decimals": 18
+      }
+    ]
+  }
+]

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/metadata/arbitrum.protocol-token.json
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/metadata/arbitrum.protocol-token.json
@@ -6,7 +6,7 @@
     "decimals": 18,
     "underlyingTokens": [
       {
-        "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+        "address": "0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C",
         "symbol": "USDM",
         "name": "Mountain Protocol USD",
         "decimals": 18

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/metadata/base.protocol-token.json
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/metadata/base.protocol-token.json
@@ -1,0 +1,16 @@
+[
+  {
+    "address": "0x57F5E098CaD7A3D1Eed53991D4d66C45C9AF7812",
+    "name": "Wrapped Mountain Protocol USD",
+    "symbol": "wUSDM",
+    "decimals": 18,
+    "underlyingTokens": [
+      {
+        "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+        "symbol": "USDM",
+        "name": "Mountain Protocol USD",
+        "decimals": 18
+      }
+    ]
+  }
+]

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/metadata/base.protocol-token.json
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/metadata/base.protocol-token.json
@@ -6,7 +6,7 @@
     "decimals": 18,
     "underlyingTokens": [
       {
-        "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+        "address": "0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C",
         "symbol": "USDM",
         "name": "Mountain Protocol USD",
         "decimals": 18

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/metadata/ethereum.protocol-token.json
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/metadata/ethereum.protocol-token.json
@@ -1,0 +1,16 @@
+[
+  {
+    "address": "0x57F5E098CaD7A3D1Eed53991D4d66C45C9AF7812",
+    "name": "Wrapped Mountain Protocol USD",
+    "symbol": "wUSDM",
+    "decimals": 18,
+    "underlyingTokens": [
+      {
+        "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+        "symbol": "USDM",
+        "name": "Mountain Protocol USD",
+        "decimals": 18
+      }
+    ]
+  }
+]

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/metadata/ethereum.protocol-token.json
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/metadata/ethereum.protocol-token.json
@@ -6,7 +6,7 @@
     "decimals": 18,
     "underlyingTokens": [
       {
-        "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+        "address": "0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C",
         "symbol": "USDM",
         "name": "Mountain Protocol USD",
         "decimals": 18

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/metadata/optimism.protocol-token.json
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/metadata/optimism.protocol-token.json
@@ -1,0 +1,16 @@
+[
+  {
+    "address": "0x57F5E098CaD7A3D1Eed53991D4d66C45C9AF7812",
+    "name": "Wrapped Mountain Protocol USD",
+    "symbol": "wUSDM",
+    "decimals": 18,
+    "underlyingTokens": [
+      {
+        "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+        "symbol": "USDM",
+        "name": "Mountain Protocol USD",
+        "decimals": 18
+      }
+    ]
+  }
+]

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/metadata/optimism.protocol-token.json
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/metadata/optimism.protocol-token.json
@@ -6,7 +6,7 @@
     "decimals": 18,
     "underlyingTokens": [
       {
-        "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+        "address": "0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C",
         "symbol": "USDM",
         "name": "Mountain Protocol USD",
         "decimals": 18

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/metadata/polygon.protocol-token.json
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/metadata/polygon.protocol-token.json
@@ -1,0 +1,16 @@
+[
+  {
+    "address": "0x57F5E098CaD7A3D1Eed53991D4d66C45C9AF7812",
+    "name": "Wrapped Mountain Protocol USD",
+    "symbol": "wUSDM",
+    "decimals": 18,
+    "underlyingTokens": [
+      {
+        "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+        "symbol": "USDM",
+        "name": "Mountain Protocol USD",
+        "decimals": 18
+      }
+    ]
+  }
+]

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/metadata/polygon.protocol-token.json
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/metadata/polygon.protocol-token.json
@@ -6,7 +6,7 @@
     "decimals": 18,
     "underlyingTokens": [
       {
-        "address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
+        "address": "0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C",
         "symbol": "USDM",
         "name": "Mountain Protocol USD",
         "decimals": 18

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/mountainProtocolWUsdmAdapter.ts
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/mountainProtocolWUsdmAdapter.ts
@@ -54,7 +54,7 @@ export class MountainProtocolWUsdmAdapter extends SimplePoolAdapter<AdditionalMe
         decimals: 18,
         underlyingTokens: [
           {
-            address: '0x59d9356e565ab3a36dd77763fc0d87feaf85508c',
+            address: '0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C',
             name: 'Mountain Protocol USD',
             symbol: 'USDM',
             decimals: 18,

--- a/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/mountainProtocolWUsdmAdapter.ts
+++ b/packages/adapters-library/src/adapters/mountain-protocol/products/wusdm/mountainProtocolWUsdmAdapter.ts
@@ -54,7 +54,7 @@ export class MountainProtocolWUsdmAdapter extends SimplePoolAdapter<AdditionalMe
         decimals: 18,
         underlyingTokens: [
           {
-            address: '0x59D9356E565Ab3A36dD77763Fc0d87fEaf85508C',
+            address: '0x59d9356e565ab3a36dd77763fc0d87feaf85508c',
             name: 'Mountain Protocol USD',
             symbol: 'USDM',
             decimals: 18,
@@ -143,41 +143,41 @@ export class MountainProtocolWUsdmAdapter extends SimplePoolAdapter<AdditionalMe
    *
    * TODO: Replace code with actual implementation logic according to your protocol's requirements and the actions supported.
    */
-  async getTransactionParams({
-    action,
-    inputs,
-  }: Extract<
-    GetTransactionParams,
-    { protocolId: typeof Protocol.MountainProtocol; productId: 'wusdm' }
-  >): Promise<{ to: string; data: string }> {
-    // Example switch case structure for implementation:
-    const poolContract = Wusdm__factory.connect(
-      '0x57F5E098CaD7A3D1Eed53991D4d66C45C9AF7812',
-      this.provider,
-    )
+  // async getTransactionParams({
+  //   action,
+  //   inputs,
+  // }: Extract<
+  //   GetTransactionParams,
+  //   { protocolId: typeof Protocol.MountainProtocol; productId: 'wusdm' }
+  // >): Promise<{ to: string; data: string }> {
+  //   // Example switch case structure for implementation:
+  //   const poolContract = Wusdm__factory.connect(
+  //     '0x57F5E098CaD7A3D1Eed53991D4d66C45C9AF7812',
+  //     this.provider,
+  //   )
 
-    switch (action) {
-      case WriteActions.Deposit: {
-        const { amount, to } = inputs
-        return poolContract.deposit.populateTransaction(amount, to)
-      }
-      case WriteActions.Withdraw: {
-        const { amount, from } = inputs
-        return poolContract.redeem.populateTransaction(amount, from, from)
-      }
-      default:
-        throw new Error('Action not supported')
-    }
-  }
+  //   switch (action) {
+  //     case WriteActions.Deposit: {
+  //       const { amount, to } = inputs
+  //       return poolContract.deposit.populateTransaction(amount, to)
+  //     }
+  //     case WriteActions.Withdraw: {
+  //       const { amount, from } = inputs
+  //       return poolContract.redeem.populateTransaction(amount, from, from)
+  //     }
+  //     default:
+  //       throw new Error('Action not supported')
+  //   }
+  // }
 }
 
-export const WriteActionInputs = {
-  [WriteActions.Deposit]: z.object({
-    amount: z.string(),
-    to: z.string(),
-  }),
-  [WriteActions.Withdraw]: z.object({
-    amount: z.string(),
-    from: z.string(),
-  }),
-} satisfies WriteActionInputSchemas
+// export const WriteActionInputs = {
+//   [WriteActions.Deposit]: z.object({
+//     amount: z.string(),
+//     to: z.string(),
+//   }),
+//   [WriteActions.Withdraw]: z.object({
+//     amount: z.string(),
+//     from: z.string(),
+//   }),
+// } satisfies WriteActionInputSchemas

--- a/packages/adapters-library/src/core/metadata/AdapterMetadata.ts
+++ b/packages/adapters-library/src/core/metadata/AdapterMetadata.ts
@@ -237,6 +237,27 @@ import StakeWiseOsEthEthereumProtocolToken from '../../adapters/stakewise/produc
 import SwellSwEthEthereumProtocolToken from '../../adapters/swell/products/sw-eth/metadata/ethereum.protocol-token.json'
 
 import LidoWstEthEthereumProtocolToken from '../../adapters/lido/products/wst-eth/metadata/ethereum.protocol-token.json'
+
+import MountainProtocolUSDMEthereumProtocolToken from '../../adapters/mountain-protocol/products/usdm/metadata/ethereum.protocol-token.json'
+
+import MountainProtocolUSDMArbitrumProtocolToken from '../../adapters/mountain-protocol/products/usdm/metadata/arbitrum.protocol-token.json'
+
+import MountainProtocolUSDMPolygonProtocolToken from '../../adapters/mountain-protocol/products/usdm/metadata/polygon.protocol-token.json'
+
+import MountainProtocolUSDMBaseProtocolToken from '../../adapters/mountain-protocol/products/usdm/metadata/base.protocol-token.json'
+
+import MountainProtocolUSDMOptimismProtocolToken from '../../adapters/mountain-protocol/products/usdm/metadata/optimism.protocol-token.json'
+
+import MountainProtocolWUSDMEthereumProtocolToken from '../../adapters/mountain-protocol/products/wusdm/metadata/ethereum.protocol-token.json'
+
+import MountainProtocolWUSDMBaseProtocolToken from '../../adapters/mountain-protocol/products/wusdm/metadata/base.protocol-token.json'
+
+import MountainProtocolWUSDMArbitrumProtocolToken from '../../adapters/mountain-protocol/products/wusdm/metadata/arbitrum.protocol-token.json'
+
+import MountainProtocolWUSDMPolygonProtocolToken from '../../adapters/mountain-protocol/products/wusdm/metadata/polygon.protocol-token.json'
+
+import MountainProtocolWUSDMOptimismProtocolToken from '../../adapters/mountain-protocol/products/wusdm/metadata/optimism.protocol-token.json'
+
 import MorphoBlueVaultEthereumProtocolToken from '../../adapters/morpho-blue/products/vault/metadata/ethereum.protocol-token.json'
 
 import MorphoBlueMarketSupplyBaseMarketSupply from '../../adapters/morpho-blue/products/market-supply/metadata/base.market-supply.json'
@@ -1352,6 +1373,96 @@ export const MetadataFiles = new Map<string, Json>([
       fileKey: 'optimizer-supply',
     }),
     MorphoCompoundV2OptimizerSupplyEthereumOptimizerSupply,
+  ],
+  [
+    metadataKey({
+      protocolId: Protocol.MountainProtocol,
+      productId: 'usdm',
+      chainId: Chain.Ethereum,
+      fileKey: 'protocol-token',
+    }),
+    MountainProtocolUSDMEthereumProtocolToken,
+  ],
+  [
+    metadataKey({
+      protocolId: Protocol.MountainProtocol,
+      productId: 'usdm',
+      chainId: Chain.Polygon,
+      fileKey: 'protocol-token',
+    }),
+    MountainProtocolUSDMPolygonProtocolToken,
+  ],
+  [
+    metadataKey({
+      protocolId: Protocol.MountainProtocol,
+      productId: 'usdm',
+      chainId: Chain.Arbitrum,
+      fileKey: 'protocol-token',
+    }),
+    MountainProtocolUSDMArbitrumProtocolToken,
+  ],
+  [
+    metadataKey({
+      protocolId: Protocol.MountainProtocol,
+      productId: 'usdm',
+      chainId: Chain.Optimism,
+      fileKey: 'protocol-token',
+    }),
+    MountainProtocolUSDMOptimismProtocolToken,
+  ],
+  [
+    metadataKey({
+      protocolId: Protocol.MountainProtocol,
+      productId: 'usdm',
+      chainId: Chain.Base,
+      fileKey: 'protocol-token',
+    }),
+    MountainProtocolUSDMBaseProtocolToken,
+  ],
+  [
+    metadataKey({
+      protocolId: Protocol.MountainProtocol,
+      productId: 'wusdm',
+      chainId: Chain.Ethereum,
+      fileKey: 'protocol-token',
+    }),
+    MountainProtocolWUSDMEthereumProtocolToken,
+  ],
+  [
+    metadataKey({
+      protocolId: Protocol.MountainProtocol,
+      productId: 'wusdm',
+      chainId: Chain.Polygon,
+      fileKey: 'protocol-token',
+    }),
+    MountainProtocolWUSDMPolygonProtocolToken,
+  ],
+  [
+    metadataKey({
+      protocolId: Protocol.MountainProtocol,
+      productId: 'wusdm',
+      chainId: Chain.Arbitrum,
+      fileKey: 'protocol-token',
+    }),
+    MountainProtocolWUSDMArbitrumProtocolToken,
+  ],
+  [
+    metadataKey({
+      protocolId: Protocol.MountainProtocol,
+      productId: 'wusdm',
+      chainId: Chain.Optimism,
+      fileKey: 'protocol-token',
+    }),
+    MountainProtocolWUSDMOptimismProtocolToken,
+  ],
+  [
+    metadataKey({
+      protocolId: Protocol.MountainProtocol,
+      productId: 'wusdm',
+      chainId: Chain.Base,
+      fileKey: 'protocol-token',
+    }),
+    MountainProtocolWUSDMBaseProtocolToken,
   ],
   [
     metadataKey({


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request. Include relevant links to the protocol docs
-->

## **Pre-merge author checklist**

- [ ] A brief description of the protocol and adapters is added to the PR
- [ ] Files outside the protocol folder are not being edited and, if they are, it's clearly explained why in the PR
- [ ] `update me` comments are removed
- [ ] Contracts used are verified for that chain block explorer
- [ ] Test cases with a block number have been added to the `testCases.ts` file for every relevant method that has been implemented
  - [ ] positions
  - [ ] profits
  - [ ] prices (unwrap)
  - [ ] deposits
  - [ ] withdrawals
  - [ ] repays
  - [ ] borrows
  - [ ] tvl
- [ ] `getAddress` from `ethers`
  - [ ] Is used to parse hardcoded addresses
  - [ ] Is used to parse addresses that come from contract calls when it is not clear they'll be in checksum format
  - [ ] It is NOT used to parse addresses from input methods
  - [ ] It is NOT used to parse addresses from metadata
- [ ] For every adapter that extends `SimplePoolAdapter`
  - [ ] `getPositions` is not overwritten and, if it is, it's clearly explained why in the PR
  - [ ] `unwrap` is not overwritten and, if it is, it's clearly explained why in the PR
- [ ] If the adapters requires to fetch static data on-chain (e.g. pool ids, token metadata, etc)
  - [ ] The adapter implements `IMetadataBuilder`
  - [ ] The `buildMetadata` method is implemented with the `@CacheToFile` decorator
  - [ ] All the static data is stored within the metadata JSON file
